### PR TITLE
PHP7 compatibility fix for spatial traits

### DIFF
--- a/src/Traits/Spatial.php
+++ b/src/Traits/Spatial.php
@@ -40,7 +40,7 @@ trait Spatial
                         $coords[] = [
                             //left most returned array ($lngLat) value corresponds to lng and right most corresponds to lat
                             'lng' => $lngLat[0],
-                            'lat' => $lngLat[1]
+                            'lat' => $lngLat[1],
                         ];
                     }
                 }

--- a/src/Traits/Spatial.php
+++ b/src/Traits/Spatial.php
@@ -36,11 +36,10 @@ trait Spatial
                 $clear = trim(preg_replace('/[a-zA-Z\(\)]/', '', $this->getLocation($column)));
                 if (!empty($clear)) {
                     foreach (explode(',', $clear) as $point) {
-                        $lngLat = explode(' ', $point);
+                        list($lng, $lat) = explode(' ', $point);
                         $coords[] = [
-                            //left most returned array ($lngLat) value corresponds to lng and right most corresponds to lat
-                            'lng' => $lngLat[0],
-                            'lat' => $lngLat[1],
+                            'lat' => $lat,
+                            'lng' => $lng,
                         ];
                     }
                 }

--- a/src/Traits/Spatial.php
+++ b/src/Traits/Spatial.php
@@ -36,10 +36,11 @@ trait Spatial
                 $clear = trim(preg_replace('/[a-zA-Z\(\)]/', '', $this->getLocation($column)));
                 if (!empty($clear)) {
                     foreach (explode(',', $clear) as $point) {
-                        list($lat, $lng) = explode(' ', $point);
+                        $lngLat = explode(' ', $point);
                         $coords[] = [
-                            'lat' => $lat,
-                            'lng' => $lng,
+                            //left most returned array ($lngLat) value corresponds to lng and right most corresponds to lat
+                            'lng' => $lngLat[0],
+                            'lat' => $lngLat[1]
                         ];
                     }
                 }


### PR DESCRIPTION
Getting `lat `and `lng `data from point value with the `list` function is ambiguous and incoherent between `PHP5 `and `PHP7`
This lead to wrong or right location coords depending on the verion of php you use
Excerpt from PHP.net documentation below ([php list function](http://php.net/manual/en/function.list.php))

> Warning
> In PHP 5, list() assigns the values starting with the right-most parameter. In PHP 7, list() starts with the left-most parameter.
> 
> If you are using plain variables, you don't have to worry about this. But if you are using arrays with indices you usually expect the order of the indices in the array the same you wrote in the list() from left to right, which is not the case in PHP 5, as it's assigned in the reverse order.
> 
> Generally speaking, it is advisable to avoid relying on a specific order of operation, as this may change again in the future.

> Warning
> Modification of the array during list() execution (e.g. using list($a, $b) = $b) results in undefined behavior.